### PR TITLE
Component should only update if a player exists

### DIFF
--- a/src/jwplayer.jsx
+++ b/src/jwplayer.jsx
@@ -43,11 +43,13 @@ class JWPlayer extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (this.didOnEventsChange(nextProps)) {
-      this.updateOnEventListener(nextProps);
-      return false;
+    if (this.player) {
+      if (this.didOnEventsChange(nextProps)) {
+        this.updateOnEventListener(nextProps);
+        return false;
+      }
+      return true;
     }
-    return true;
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
### This PR will...
- In `shouldComponentUpdate()` we are checking if the player exists, and will then update event listeners. Currently event listeners are being updated before a player exists and that causes errors.

### Why is this Pull Request needed?
- Currently the player is not usable with `on<Event>` listeners.

### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
- No

#### Addresses Issue(s):
- https://github.com/jwplayer/jwplayer-react/issues/12
