### PR TITLE
Add TypeScript typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2955,6 +2955,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "node_modules/@types/jwplayer": {
+      "version": "8.28.4",
+      "resolved": "https://registry.npmjs.org/@types/jwplayer/-/jwplayer-8.28.4.tgz",
+      "integrity": "sha512-do47k7UASeDSnaZRZU71OmVv6KZ4F1mgkXOmljbu2uiT38jeE+ecxaL7ZkWggYg6xGqqSYmkLrjl4E6aOBqoHA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -13427,6 +13433,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/jwplayer": {
+      "version": "8.28.4",
+      "resolved": "https://registry.npmjs.org/@types/jwplayer/-/jwplayer-8.28.4.tgz",
+      "integrity": "sha512-do47k7UASeDSnaZRZU71OmVv6KZ4F1mgkXOmljbu2uiT38jeE+ecxaL7ZkWggYg6xGqqSYmkLrjl4E6aOBqoHA==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "url": "https://github.com/jwplayer/jwplayer-react/issues"
   },
   "main": "./lib/jwplayer-react.js",
+  "types": "types/jwplayer-react.d.ts",
+  "files": [
+    "lib",
+    "types"
+  ],
   "scripts": {
     "build": "webpack && npm run badges:build:passing || npm run badges:build:failing",
     "ci": "npm ci; npm run build; npm run test; npm run lint; npm run badges:license",
@@ -34,6 +39,7 @@
     "@babel/preset-env": "7.16.11",
     "@babel/preset-react": "7.16.7",
     "@testing-library/react": "12.1.4",
+    "@types/jwplayer": "^8.28.4",
     "@typescript-eslint/eslint-plugin": "5.59.6",
     "@typescript-eslint/parser": "5.59.6",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",

--- a/types/jwplayer-react.d.ts
+++ b/types/jwplayer-react.d.ts
@@ -98,7 +98,7 @@ declare module '@jwplayer/jwplayer-react' {
         config?: JWPlayerConfig;
     }
 
-    const JWPlayerComponent: ComponentType<JWPlayerProps & HTMLProps<'video'>>;
+    const JWPlayerComponent: ComponentType<JWPlayerProps & HTMLProps<HTMLVideoElement>>;
 
     export default JWPlayerComponent;
 }

--- a/types/jwplayer-react.d.ts
+++ b/types/jwplayer-react.d.ts
@@ -1,6 +1,5 @@
 declare module '@jwplayer/jwplayer-react' {
-    import React from 'react';
-    import jwplayer from './jwplayer';
+    import type { ComponentType, HTMLProps } from 'react';
 
     /**
      * Example: {"2500":"High","1000":"Medium"}
@@ -99,7 +98,7 @@ declare module '@jwplayer/jwplayer-react' {
         config?: JWPlayerConfig;
     }
 
-    const JWPlayerComponent = React.Component<JWPlayerProps & React.HTMLProps<'video'>>;
+    const JWPlayerComponent: ComponentType<JWPlayerProps & HTMLProps<'video'>>;
 
     export default JWPlayerComponent;
 }


### PR DESCRIPTION
### This PR will...

Add `@jwplayer/jwplayer-react` TypeScript types

### Why is this Pull Request needed?

Cannot find module '@jwplayer/jwplayer-react' or its corresponding type declarations.

![CleanShot 2024-03-25 at 16 10 20@2x](https://github.com/jwplayer/jwplayer-react/assets/559351/c7ac5212-2c74-4e72-af60-27290e0a8710)

### Are there any points in the code the reviewer needs to double check?

After `npm publish`, you can use tools like CodeSandbox to create a React TypeScript project to check whether `import JWPlayer from '@jwplayer/jwplayer-react'` will still display this error message.

### Are there any Pull Requests open in other repos which need to be merged with this?

N/A

#### Addresses Issue(s):

#4 
